### PR TITLE
Fixed typo for Fog::Rackspace::NetworkingV2 instead of Fog::Rackspace::NetworkV2

### DIFF
--- a/lib/shared/cookbooks/shared/recipes/set_provider.rb
+++ b/lib/shared/cookbooks/shared/recipes/set_provider.rb
@@ -61,7 +61,7 @@ when /rackspace/
     :rackspace_region => cloud[:region]
   })
 
-  network_provider = Fog::Rackspace::NetworkV2.new({
+  network_provider = Fog::Rackspace::NetworkingV2.new({
     :rackspace_api_key => cloud[:password],
     :rackspace_username => cloud[:username],
     :rackspace_region => cloud[:region]


### PR DESCRIPTION
Fixed typo for Fog::Rackspace::NetworkingV2 instead of Fog::Rackspace::NetworkV2, this should fixed the issue that was merged in from commit: 276c1945a00e4221ef374f0eaf195e1592579bfd