### PR TITLE
Enable local gem cache by default on inductor add.

### DIFF
--- a/lib/inductor.rb
+++ b/lib/inductor.rb
@@ -33,7 +33,9 @@ class Inductor < Thor
     # chmod exec-order.rb
     `chmod +x #{options[:path]}/shared/exec-order.rb`
 
-    if ENV.has_key?("USE_GEM_CACHE")
+    # Check if local gem cache is enabled. Default value is yes.
+    use_gem_cache = (ENV['USE_GEM_CACHE'] || 'yes').downcase == 'yes'
+    if use_gem_cache
       gem_paths = `gem env path`.chomp.split(":")
       gem_paths.each do |path|
         run("cp #{path}/cache/* #{options[:path]}/shared/cookbooks/vendor/cache/")


### PR DESCRIPTION
Enable vendor gem cache by default (i.e if no `USE_GEM_CACHE` set). If the env variable is set, it will honor that value (`yes/no`). Tested on centos 7 and local inductor (mac)