### PR TITLE
Azure gems for computes.

### DIFF
--- a/lib/shared/cookbooks/shared/recipes/set_provider.rb
+++ b/lib/shared/cookbooks/shared/recipes/set_provider.rb
@@ -106,13 +106,15 @@ when /rackspace/
     :rackspace_api_key => cloud[:password],
     :rackspace_username => cloud[:username],
     :rackspace_region => cloud[:region]
-  })  
+  }) 
+when /azure/
+  provider_class = "azureblobs" 
 end
 
 
 if !node.has_key?(:storage_provider) || node.storage_provider == nil
-  node.set[:storage_provider] = provider
-  node.set[:storage_provider_class] = provider_class
+     node.set[:storage_provider] = provider
+     node.set[:storage_provider_class] = provider_class
 end
 
 node.set[:iaas_provider] = provider

--- a/lib/shared/cookbooks/shared/recipes/set_provider.rb
+++ b/lib/shared/cookbooks/shared/recipes/set_provider.rb
@@ -108,7 +108,7 @@ when /rackspace/
     :rackspace_region => cloud[:region]
   }) 
 when /azure/
-  provider_class = "azureblobs" 
+  provider_class = "azuredatadisk" 
 end
 
 

--- a/lib/shared/exec-gems.yaml
+++ b/lib/shared/exec-gems.yaml
@@ -20,6 +20,24 @@ common:
     -
       - highline
       - 1.6.21
+    -
+      - ms_rest
+      - 0.1.1
+    -
+      - ms_rest_azure
+      - 0.1.1
+    -
+      - azure_mgmt_compute
+      - 0.1.1
+    -
+      - azure_mgmt_network
+      - 0.1.1
+    -
+      - azure_mgmt_storage
+      - 0.1.1
+    -
+      - azure_mgmt_resources
+      - 0.1.1
 
 chef-10.16.6:
     # workaround for chef install dependency issues

--- a/oneops-admin.gemspec
+++ b/oneops-admin.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency "azure_mgmt_storage", '= 0.1.1'
   s.add_dependency "azure_mgmt_network", '= 0.1.1'
   s.add_dependency "azure_mgmt_resources", '= 0.1.1'
-  s.add_dependency "azure", '= 0.7.1'
+  s.add_dependency "azure", '= 0.6.4'
   
   s.add_dependency "rake", '= 10.1.1'
 

--- a/oneops-admin.gemspec
+++ b/oneops-admin.gemspec
@@ -40,6 +40,8 @@ Gem::Specification.new do |s|
   s.add_dependency "azure_mgmt_storage", '= 0.1.1'
   s.add_dependency "azure_mgmt_network", '= 0.1.1'
   s.add_dependency "azure_mgmt_resources", '= 0.1.1'
+  s.add_dependency "azure", '= 0.7.1'
+  
   s.add_dependency "rake", '= 10.1.1'
 
   s.bindir       = 'bin'


### PR DESCRIPTION
Added azure gems which needs to be installed on computes to support azure storage recipes .  the azure storage recipes needs to be executed remotely so these gems need to be present on the computes. There are changes in set_provider.rb to support azure storage service.