### PR TITLE
Changing default Logstash forwarder spool size.

### DIFF
--- a/lib/inductor.rb
+++ b/lib/inductor.rb
@@ -339,7 +339,7 @@ class Inductor < Thor
       if status_result.to_i > 0
         say_status("start","#{long_cloud} logstash_agent already running",:green)
       else
-        cmd = "exec nohup #{Inductor.logstash_forwarder} -config=#{conf_file} >#{log_file} 2>&1 &"
+        cmd = "exec nohup #{Inductor.logstash_forwarder} -config=#{conf_file} -spool-size 20 >#{log_file} 2>&1 &"
         inside(long_path) do
           run("#{cmd}", :verbose => options[:verbose])
         end


### PR DESCRIPTION
Changing LSF spool size to 20 to avoid buffer overflow errors