### PR TITLE
Add Aliyun (Alibaba Cloud) support

### DIFF
--- a/lib/shared/cookbooks/shared/recipes/set_provider.rb
+++ b/lib/shared/cookbooks/shared/recipes/set_provider.rb
@@ -68,6 +68,17 @@ when /rackspace/
   })
   node.set["network_provider"] = network_provider
 
+when /aliyun/
+  require 'fog/aliyun'
+  provider = Fog::Compute.new({
+    :provider => 'aliyun',
+    :aliyun_region_id => cloud[:region],
+    :aliyun_zone_id => '', # "aliyun_zone_id" is not a required parameter
+    :aliyun_url => cloud[:url],
+    :aliyun_accesskey_id => cloud[:key],
+    :aliyun_accesskey_secret => cloud[:secret]
+  })
+
 when /azure/
   provider = 'azure'
 

--- a/lib/shared/exec-gems.yaml
+++ b/lib/shared/exec-gems.yaml
@@ -23,6 +23,9 @@ common:
     -
       - rack
       - 1.6.4
+    -
+      - fog-aliyun
+      - 0.1.0
 
 chef-10.16.6:
     # workaround for chef install dependency issues

--- a/oneops-admin.gemspec
+++ b/oneops-admin.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rack", '= 1.6.4'
 
   s.add_dependency "rake", '= 10.1.1'
-
+  s.add_dependency "fog-aliyun", '= 0.1.0'
   s.bindir       = 'bin'
   s.require_path = 'lib'
   s.files        = %w() + ["oneops-admin.gemspec"] + ["Gemfile"] + Dir.glob(".chef/**/*") + Dir.glob("lib/**/*") + ["target/inductor-#{Inductor::VERSION}.jar"] + Dir.glob('bin/**/*')


### PR DESCRIPTION
Similar to EC2, Aliyun uses `fog-aliyun` to interact with the Alibaba Cloud.