### PR TITLE
Ruby version < 2.0 requires net/https

### DIFF
--- a/lib/shared/cookbooks/artifact/libraries/chef_rest.rb
+++ b/lib/shared/cookbooks/artifact/libraries/chef_rest.rb
@@ -208,7 +208,7 @@ class Chef
         Chef::Log.debug("Requesting slot: #{part['slot']} from [#{part['start']} to #{part['end']}]")
         req.add_field('Range', "bytes=#{part['start']}-#{part['end']}")
         if ssl
-          htpp.use_ssl = true
+          http.use_ssl = true
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE
         end
 


### PR DESCRIPTION
Ruby version < 2.0 requires net/https where as later version doesn't need to.  

Also SSL directive is set via http not request.