### PR TITLE
Fixed URI syntax in older Ruby version.

### DIFF
--- a/lib/shared/cookbooks/artifact/libraries/chef_rest.rb
+++ b/lib/shared/cookbooks/artifact/libraries/chef_rest.rb
@@ -68,8 +68,13 @@ class Chef
     def download_file_single(remote_file, local_file)
       Chef::Log.debug("Saving file to #{local_file}")
       Chef::Log.info("Fetching file: #{remote_file}")
-      url_uri = URI(remote_file)
 
+      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
+        url_uri = URI.parse(remote_file.to_s)
+      else
+        url_uri = URI(remote_file)
+      end
+      
       ssl = url_uri.scheme == "https" ? true : false
 
       if Gem::Version.new(RUBY_VERSION) > Gem::Version.new('1.8.7')


### PR DESCRIPTION
…hus must be explicitly check for and use appropriate function call to get the same behavior as the new version