### PR TITLE
Added check_load monitor for windows

### DIFF
--- a/lib/shared/cookbooks/monitor/files/windows/check_load
+++ b/lib/shared/cookbooks/monitor/files/windows/check_load
@@ -1,0 +1,3 @@
+#!/bin/bash
+#this currently always returns 0s as /proc/loadavg is not really supported in cygwin
+cat /proc/loadavg | awk '{print "load1="$1";"$2";"$3";0; load5="$1";"$2";"$3";0; load15="$1";"$2";"$3";0;|load1="$1";"$2";"$3";0; load5="$1";"$2";"$3";0; load15="$1";"$2";"$3";0;"}'

--- a/lib/shared/cookbooks/monitor/recipes/install_nagios.rb
+++ b/lib/shared/cookbooks/monitor/recipes/install_nagios.rb
@@ -147,6 +147,11 @@ if node.platform =~ /windows/
 	content "c:/opt /opt"
 	only_if{File.directory?("C:/tools/DevKit2/etc")}
   end
+  
+  #Adding check_load for windows - in linux it's coming from nagios plugin, but for windows we write a simple bash script, that currently only returns 0s
+  cookbook_file "/opt/nagios/libexec/check_load" do
+	source "check_load"
+  end
 end
 
 #Create necessary directories


### PR DESCRIPTION
This is not a real monitor, it always returns 0s, as it uses /proc/loadavg file which is not really supported in cygwin