### PR TITLE
fix frozen string issue when using RUBY_VERSION in older rubygem version

### DIFF
--- a/lib/shared/cookbooks/artifact/libraries/chef_rest.rb
+++ b/lib/shared/cookbooks/artifact/libraries/chef_rest.rb
@@ -1,5 +1,5 @@
 require 'net/http'
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
+if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
   require 'net/https'
 end
 require 'tempfile'
@@ -36,7 +36,7 @@ class Chef
       uri = URI(url_path)
       ssl = uri.scheme == "https" ? true : false
       headers_h = nil
-      if Gem::Version.new(RUBY_VERSION) > Gem::Version.new('1.8.7')
+      if Gem::Version.new(RUBY_VERSION.dup) > Gem::Version.new('1.8.7')
         Net::HTTP.start(uri.host, uri.port, :use_ssl => ssl) { |http|
           url_path = !uri.query.nil? ? "#{uri.path}?#{uri.query}" : uri.path
           headers = http.head(url_path)
@@ -73,7 +73,7 @@ class Chef
       Chef::Log.debug("Saving file to #{local_file}")
       Chef::Log.info("Fetching file: #{remote_file}")
 
-      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
+      if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
         url_uri = URI.parse(remote_file.to_s)
       else
         url_uri = URI(remote_file)
@@ -81,7 +81,7 @@ class Chef
       
       ssl = url_uri.scheme == "https" ? true : false
 
-      if Gem::Version.new(RUBY_VERSION) > Gem::Version.new('1.8.7')
+      if Gem::Version.new(RUBY_VERSION.dup) > Gem::Version.new('1.8.7')
         Net::HTTP.start(url_uri.host, url_uri.port, :use_ssl => ssl) do |http|
           request = Net::HTTP::Get.new url_uri
 
@@ -193,7 +193,7 @@ class Chef
 
       ssl = uri.scheme == "https" ? true : false
 
-      if Gem::Version.new(RUBY_VERSION) > Gem::Version.new('1.8.7')
+      if Gem::Version.new(RUBY_VERSION.dup) > Gem::Version.new('1.8.7')
         Net::HTTP.start(uri.host, uri.port, :use_ssl => ssl) do |http|
           request = Net::HTTP::Get.new uri
           Chef::Log.debug("Requesting slot: #{part['slot']} from [#{part['start']} to #{part['end']}]")


### PR DESCRIPTION
In older version of Rubygem when uses RUBY_VERSION it will error because it's a frozen string.  This is a workaround by duplicating the string to unfreeze it.