### PR TITLE
Add support for message fields and payload in slack notification

### DIFF
--- a/lib/base/sink/metadata.rb
+++ b/lib/base/sink/metadata.rb
@@ -61,6 +61,17 @@ attribute 'text_formats',
               :order => 2
           }
 
+attribute 'notification_fields',
+          :grouping => 'slack',
+          :description => 'Include Notification Fields',
+          :default => 'false',
+          :format => {
+              :help => 'Enable to include all notification fields in the message.',
+              :category => '1.Slack Config',
+              :form => {'field' => 'checkbox'},
+              :order => 3
+          }
+
 # sns attributes 
 attribute 'access',
           :grouping => 'sns',


### PR DESCRIPTION
Added a new checkbox to enable notification fields and payload in sink metadata. The default value is `false`.