### PR TITLE
Implement a fix for getting file from a remote server that doesn't support missing ending range.

### DIFF
--- a/lib/shared/cookbooks/artifact/libraries/chef_rest.rb
+++ b/lib/shared/cookbooks/artifact/libraries/chef_rest.rb
@@ -296,6 +296,12 @@ class Chef
           parts_details.push({'slot' => last_slot + 1, 'start' => byte_start, 'end' => '', size => size})
         end
       end
+
+      end_part = parts_details[parts_details.length-1]
+      end_part_end = end_part['end'] == '' ? end_part['start'].to_i + end_part['size'].to_i - 1: end_part['end']
+      end_part['end'] = end_part_end
+      parts_details[parts_details.length-1] = end_part
+
       parts_details
     end
   end

--- a/lib/shared/cookbooks/shared/libraries/chef_rest.rb
+++ b/lib/shared/cookbooks/shared/libraries/chef_rest.rb
@@ -282,6 +282,12 @@ class Chef
           parts_details.push({'slot' => last_slot + 1, 'start' => byte_start, 'end' => '', size => size})
         end
       end
+
+      end_part = parts_details[parts_details.length-1]
+      end_part_end = end_part['end'] == '' ? end_part['start'].to_i + end_part['size'].to_i - 1: end_part['end']
+      end_part['end'] = end_part_end
+      parts_details[parts_details.length-1] = end_part
+      
       parts_details
     end
   end


### PR DESCRIPTION
Implement a fix for getting file from a remote server that doesn't support missing ending range.

Code change

end_part_end = end_part['end'] == '' ? end_part['start'].to_i +
end_part['size'].to_i - 1: end_part['end']

This will programmatically added the ending range to the last entry