### PR TITLE
Revert "Fix issue where component with lowercase have incorrect namespace."

### DIFF
--- a/lib/chef/knife/model_sync.rb
+++ b/lib/chef/knife/model_sync.rb
@@ -119,8 +119,8 @@ class Chef
         config[:version] ||='1.0.0'
         ui.info("Processing metadata for #{cookbook} from #{file}")
         md = Chef::Cookbook::Metadata.new
-        md.from_file(file)
         md.name(cookbook.capitalize)
+        md.from_file(file)
         Chef::Log.debug(md.to_yaml)
         
         # sync_class and sync_relation return boolean


### PR DESCRIPTION
Reverts oneops/oneops-admin#183

This fix is currently prevent loading base relation.  Will revisit this once a solution is found that can satisfy both edge cases.