### PR TITLE
update fog-openstack gem to 0.1.21

### DIFF
--- a/oneops-admin.gemspec
+++ b/oneops-admin.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_dependency "azure_mgmt_resources", '= 0.1.1'
   s.add_dependency "azure", '= 0.6.4'
   s.add_dependency "fog-vsphere", '= 1.5.1'
-  s.add_dependency "fog-openstack", '= 0.1.11'
+  s.add_dependency "fog-openstack", '= 0.1.21'
   s.add_dependency "crack", '= 0.4.3'
   s.add_dependency "rack", '= 1.6.4'
 


### PR DESCRIPTION
update fog-openstack gem to 0.1.21. fog-openstack-0.1.21.gem is available in internal gem repo.
this latest gem is needed for barbican and acl support.